### PR TITLE
Changes to show today's workshops first and to fix bugs on workshop list page

### DIFF
--- a/app/controllers/WorkshopController.php
+++ b/app/controllers/WorkshopController.php
@@ -1,5 +1,4 @@
 <?php
-
 class WorkshopController extends BaseController {
     
     public function getWorkshop($id)
@@ -34,19 +33,20 @@ class WorkshopController extends BaseController {
         $perPage = 100;
         $title = 'Workshop List';
         
-        $this->wsFilterFlash();
-        
+		$this->wsFilterFlash();
         $wsName = Input::get('wsName');
-
-        $workshops = Workshop::with('series')->
+		$today = date('Y-m-d');
+		$filteredWorkshops = Workshop::with('series')->
             with('demographics')->
             wsFilter()->
             where('title', 'LIKE', '%'.$wsName.'%')->
-            orderBy('date', 'desc')->
-            paginate($perPage);
-        
-        return View::make('workshopList', array('title' => $title, 'workshops' => $workshops));
+            orderBy('date', 'desc');
+		$todaysWorkshops = with(clone $filteredWorkshops)->where('date','=',$today)->paginate($perPage);
+		$otherWorkshops = with(clone $filteredWorkshops)->where('date','<>',$today)->paginate($perPage);
+		
+        return View::make('workshopList', array('title' => $title, 'todaysWorkshops'=>$todaysWorkshops, 'otherWorkshops' =>$otherWorkshops));
     }
+	
     
     public function attend()
     {
@@ -232,4 +232,6 @@ class WorkshopController extends BaseController {
         
         return Redirect::to('WS/list');
     }
+	
+	
 }

--- a/app/models/Workshop.php
+++ b/app/models/Workshop.php
@@ -97,7 +97,11 @@ class Workshop extends Eloquent {
     
     public function scopeDateRange($query, $ds, $de)
     {
-        return $query->where('date', '>', $ds)->where('date', '<', $de);
+		if(empty($de)){
+			return $query->where('date', '>=', $ds);
+		}else{
+			return $query->where('date', '>=', $ds)->where('date', '<=', $de);
+		}
     }
     
     public function isPresenter($id)

--- a/app/views/teacherTool.blade.php
+++ b/app/views/teacherTool.blade.php
@@ -227,7 +227,7 @@
             {{ Form::text('CCT_disc_spec', isset($teacher->CCT_disc_spec) ? $teacher->CCT_disc_spec : '', $dis) }}
             signed off by {{ Form::who('CCT_disc_spec_who', $teacher, $dtext) }}
 
-        <label for="CCT_obser_date">Classroom Observation</label>
+        <label for="CCT_obser_date">Faculty Observation</label>
             Observed by {{ Form::who('CCT_obser_who', $teacher, $dtext) }}
             on {{ Form::date('CCT_obser_date', $teacher, $dtext) }}
 
@@ -262,7 +262,7 @@
 
 <!-- --------------------------------------------------------------------------------------------- -->
 <div class="dontBreak">
-    <h2 class="section">Professional Development Certificate Information:</h2>
+    <h2 class="section">Future Faculty Development Certificate Information:</h2>
     <hr />
 
     <fieldset>

--- a/app/views/workshopList.blade.php
+++ b/app/views/workshopList.blade.php
@@ -5,6 +5,7 @@
 <?php
 $user = Teacher::find(Session::get('user'));
 if (empty($user)) $user = new Teacher;
+$i=0;
 ?>
 
 <div style="text-align: center;">
@@ -51,55 +52,57 @@ if (empty($user)) $user = new Teacher;
     </thead>
     <tbody>
 <?php
-$i = 0;
-foreach ($workshops as $ws) {
-    $sess_ws = Session::get('workshop_id');
-    
-    if ($ws->date == date('Y-m-d')) {
-        if ($ws->id == $sess_ws) {
-            $login = Form::open(array_merge(array('url' => '/WS/stopAttend/', 'class' => 'delete', 'method' => 'get'))).Form::submit('Stop').Form::close();
-        } else {
-            $login = Form::open(array_merge(array('url' => '/WS/attend/', 'class' => 'addnew'))).Form::hidden('ws_id', $ws->id).Form::submit('Start').Form::close();
-        }
-    } else {
-        $login = Form::submit('', array('style' => 'visibility: hidden;'));
-    }
-    
-    if (!empty($ws->presenters[0]))
-        $pres = $ws->presenters[0]->name;
-    else
-        $pres = '<a href="/WS/info/'.$ws->id.'">Add presenter!</a>';
-    
-    if ($user->permissions('wsinfo'))
-        $ws_title = '<a href="/WS/info/'.$ws->id.'">'.$ws->title.'</a>';
-    else
-        $ws_title = $ws->title;
-    
-    echo '
-        <tr class="'.((($i % 2) == 0) ? 'evenRow' : 'oddRow').'">
-            <td>'.$ws_title.'</td>
-            <td>'.date_format(date_create($ws->date), 'n/d/Y').'</td>
-            <td>'.$pres.'</td>
-            <td>'.$ws->series->title.'</td>';
-    if ($user->permissions('wssignin')) {
-        echo '
-            <td>'.$login.'</td>';
-    }
-    echo '
-            <td>'.$ws->attendees->count().'</td>';
-    if ($user->permissions('fbinfo'))
-        echo '<td><a href="/FB/list/'.$ws->id.'" class="start">FB List</a></td>';
-    echo '
-        </tr>';
-    
-    $i++;
+function displayWorkshopList($workshops,$user){
+	global $i;
+	foreach ($workshops as $ws) {
+		$sess_ws = Session::get('workshop_id');
+		
+		if ($ws->date == date('Y-m-d')) {
+			if ($ws->id == $sess_ws) {
+				$login = Form::open(array_merge(array('url' => '/WS/stopAttend/', 'class' => 'delete', 'method' => 'get'))).Form::submit('Stop').Form::close();
+			} else {
+				$login = Form::open(array_merge(array('url' => '/WS/attend/', 'class' => 'addnew'))).Form::hidden('ws_id', $ws->id).Form::submit('Start').Form::close();
+			}
+		} else {
+			$login = Form::submit('', array('style' => 'visibility: hidden;'));
+		}
+		
+		if (!empty($ws->presenters[0]))
+			$pres = $ws->presenters[0]->name;
+		else
+			$pres = '<a href="/WS/info/'.$ws->id.'">Add presenter!</a>';
+		
+		if ($user->permissions('wsinfo'))
+			$ws_title = '<a href="/WS/info/'.$ws->id.'">'.$ws->title.'</a>';
+		else
+			$ws_title = $ws->title;
+		
+		echo '
+			<tr class="'.((($i % 2) == 0) ? 'evenRow' : 'oddRow').'">
+				<td>'.$ws_title.'</td>
+				<td>'.date_format(date_create($ws->date), 'n/d/Y').'</td>
+				<td>'.$pres.'</td>
+				<td>'.$ws->series->title.'</td>';
+		if ($user->permissions('wssignin')) {
+			echo '
+				<td>'.$login.'</td>';
+		}
+		echo '
+				<td>'.$ws->attendees->count().'</td>';
+		if ($user->permissions('fbinfo'))
+			echo '<td><a href="/FB/list/'.$ws->id.'" class="start">FB List</a></td>';
+		echo '
+			</tr>';
+		
+		$i++;
+	}
 }
+displayWorkshopList($todaysWorkshops,$user);
+displayWorkshopList($otherWorkshops,$user);
 ?>
     </tbody>
     <tfoot>
     </tfoot>
 </table>
-
-{{ $workshops->links() }}
-
+{{ $otherWorkshops->links() }}
 @stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
 
   db:
     image: mariadb:10.1
-    env_file:
-      - ./db_secrets.env
+    environment:
+      MYSQL_ROOT_PASSWORD: super-secret-password
+      MYSQL_DATABASE: attendtrack
+      MYSQL_USER: attendtrack
+      MYSQL_PASSWORD: password
     volumes:
       - ./sql:/docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     image: attendtrack:latest
     ports:
-      - "8080:80"
+      - "4000:80"
     stdin_open: true
     tty: true
     volumes:
@@ -15,10 +15,7 @@ services:
 
   db:
     image: mariadb:10.1
-    environment:
-      MYSQL_ROOT_PASSWORD: super-secret-password
-      MYSQL_DATABASE: attendtrack
-      MYSQL_USER: attendtrack
-      MYSQL_PASSWORD: password
+    env_file:
+      - ./db_secrets.env
     volumes:
       - ./sql:/docker-entrypoint-initdb.d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: .
     image: attendtrack:latest
     ports:
-      - "4000:80"
+      - "8080:80"
     stdin_open: true
     tty: true
     volumes:

--- a/example_db_secrets.env
+++ b/example_db_secrets.env
@@ -1,4 +1,0 @@
-MYSQL_ROOT_PASSWORD=super-secret-password
-MYSQL_DATABASE=attendtrack
-MYSQL_USER=attendtrack
-MYSQL_PASSWORD=password

--- a/example_db_secrets.env
+++ b/example_db_secrets.env
@@ -1,0 +1,4 @@
+MYSQL_ROOT_PASSWORD=super-secret-password
+MYSQL_DATABASE=attendtrack
+MYSQL_USER=attendtrack
+MYSQL_PASSWORD=password


### PR DESCRIPTION
This PR contains changes to
1) Workshop list page - to show today's workshops first and then all other workshops in descending order
2) Fix bugs found on workshop list page:
- Date filter is exclusive of both start and end dates - made it inclusive
- End date is defaulted to today's date- doesn't work when start date is greater than today's date. Made changes to query by date>=start date when end date is empty.
3) Revoke changes to docker-compose.yml which are not required as per our discussion. Removed .env file from root. 
4) Label changes to Classroom Observation and Professional Development Certificate Information, which were already committed to this branch but are not merged before.