### PR TITLE
Delete a workshop from workshop list page.

### DIFF
--- a/app/controllers/WorkshopController.php
+++ b/app/controllers/WorkshopController.php
@@ -233,5 +233,27 @@ class WorkshopController extends BaseController {
         return Redirect::to('WS/list');
     }
 	
+	public function remWorkshop()
+    {
+        $ws = Workshop::find(Input::get('ws_id'));
+		$att_records = Attendance::where('workshop_id','=', $ws->id)->get();
+		$fb_records = Feedback::where('workshop_id','=', $ws->id)->get();
+		$ps_records = Presenter::where('workshop_id','=', $ws->id)->get();
+        
+		foreach($att_records as $att){
+			$att->delete();
+		}
+		foreach($fb_records as $fb){
+			$fb->delete();
+		}
+		foreach($ps_records as $ps){
+			$ps->delete();
+		}
+        
+        $this->logAction('delete', 'WS'.$ws->id);
+        $ws->delete();
+        
+        return Redirect::to('WS/list');
+    }
 	
 }

--- a/app/routes.php
+++ b/app/routes.php
@@ -147,6 +147,8 @@ Route::post('WS/presAdd/', array('before' => 'isGTP:wsinfo', 'uses' => 'Workshop
 
 Route::post('WS/attCred/', array('before' => 'isGTP:attendance', 'uses' => 'WorkshopController@editAttendance'));
 
+// Delete a workshop
+Route::post('WS/delWS/', array('before' => 'isGTP:wsinfo', 'uses' => 'WorkshopController@remWorkshop'));
 
 /* ------------------------------------------------------------------------- */
 ///////                        Feedback routing                         ///////

--- a/app/views/workshopList.blade.php
+++ b/app/views/workshopList.blade.php
@@ -47,6 +47,9 @@ $i=0;
             <th>Att.</th>
             @if($user->permissions('fbinfo'))
             <th>FB Entry</th>
+			@endif
+			@if ($user->permissions('wsinfo'))
+			<th>Remove</th>
             @endif
         </tr>
     </thead>
@@ -91,6 +94,11 @@ function displayWorkshopList($workshops,$user){
 				<td>'.$ws->attendees->count().'</td>';
 		if ($user->permissions('fbinfo'))
 			echo '<td><a href="/FB/list/'.$ws->id.'" class="start">FB List</a></td>';
+		if ($user->permissions('wsinfo')){ 
+			$warn_message = "'Are you sure you want to delete the workshop: ".$ws->title."?'";
+                echo '
+                    <td>'.Form::open(array('url' => '/WS/delWS/', 'onsubmit' => "return confirm($warn_message);", 'class' => 'delete')).Form::hidden('ws_id', $ws->id).Form::submit('Remove').Form::close().'</td>';
+		}
 		echo '
 			</tr>';
 		


### PR DESCRIPTION
This PR includes changes for a new functionality: Delete workshop
1) New button on workshop list page to remove a workshop (Uses existing permission: wsinfo)
2) Warning message popup on clicking 'Remove'
3) Route to WorkshopController.remWorkshop, where the child records if any - attendance, feebdack, and presenter are deleted, before deleting the workshop record